### PR TITLE
Use generic cmake configure and build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,16 @@
 This is a terminal-based clone of the ["ALIEN: Fate of The Nostromo" board game](https://boardgamegeek.com/boardgame/332321/alien-fate-nostromo), implemented in C.
 
 ## Installation
-```
+```sh
 git clone https://github.com/CharlesAverill/aftn.git
 cd aftn
 
-mkdir build && cd build
-
-cmake ..
-make
+cmake -S . -B build
+cmake --build build
 ```
 
 ## Usage
-```
+```sh
 Usage: aftn [OPTION...]
 
   -a, --use_ash              Include Ash for a more challenging game

--- a/build_run.sh
+++ b/build_run.sh
@@ -1,14 +1,12 @@
 echo "---CLANG-FORMAT----"
 clang-format -i $(find src -name "*.c") $(find include -name "*.h")
 echo "------CMAKE--------"
-cd build
 echo "CALLING 'sudo cmake ..' in order to copy important game files to /var/games"
-if sudo cmake .. ; then
+if sudo cmake -S . -B build ; then
     echo "-------MAKE--------"
-    if make -j$(nproc) ; then
-        cd ../bin
+    if cmake --build build -j$(nproc) ; then
         echo "-----EXECUTING-----"
-		./aftn $*
+        bin/aftn $*
     else
         echo "-----MAKE FAILURE-----"
     fi


### PR DESCRIPTION
CMake can create the out of source build directory for us, and even call
the `make` command (or any other build command like `ninja` or `msvc`)
for us.

Update the README.md and `build_run.sh` script to use this CMake
provided feature.

More info about this in the CMake documentation
https://cmake.org/cmake/help/latest/manual/cmake.1.html