### PR TITLE
Use CMake install target, C standard override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,33 @@
 cmake_minimum_required(VERSION 3.14)
 project(aftn C)
 
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
-set(CMAKE_BUILD_TYPE Debug)
+# https://cmake.org/cmake/help/latest/prop_tgt/C_STANDARD.html
+string(COMPARE EQUAL "${CMAKE_C_STANDARD}" "" no_cmake_c_standard_set)
+if(no_cmake_cxx_standard_set)
+    set(CMAKE_C_STANDARD 11)
+    set(CMAKE_C_STANDARD_REQUIRED ON)
+    set(CMAKE_C_EXTENSIONS OFF)
+    message(STATUS "Using default C standard ${CMAKE_C_STANDARD}")
+else()
+    message(STATUS "Using user specified C standard ${CMAKE_C_STANDARD}")
+endif()
 
-message("Call with -DInstallMaterials=ON to install copies of the game manual and game pieces to /var/games/aftn/game_data/materials")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
+set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type on single-configuration generators")
+
+set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "Install directory used by install()")
+message("Call with -DInstallMaterials=ON to install copies of the game manual and game pieces to ${CMAKE_INSTALL_PREFIX}/share/games/aftn/game_data/materials")
 option(InstallMaterials "InstallMaterials" OFF)
 
-# Copy maps to /var/games/aftn
-file(MAKE_DIRECTORY /var/games/aftn)
-file(MAKE_DIRECTORY /var/games/aftn/game_data)
-file(COPY ${CMAKE_SOURCE_DIR}/game_data/maps DESTINATION /var/games/aftn/game_data)
-file(COPY ${CMAKE_SOURCE_DIR}/game_data/banner.txt DESTINATION /var/games/aftn/game_data)
+# Copy maps to install directory
+install(FILES
+    ${CMAKE_SOURCE_DIR}/game_data/maps/default
+    ${CMAKE_SOURCE_DIR}/game_data/maps/format.txt
+    DESTINATION share/games/aftn/game_data/maps)
+install(FILES ${CMAKE_SOURCE_DIR}/game_data/banner.txt DESTINATION share/games/aftn/game_data)
 
 if(InstallMaterials)
-    file(COPY ${CMAKE_SOURCE_DIR}/game_data/materials DESTINATION /var/games/aftn/game_data)
+    install(FILES ${CMAKE_SOURCE_DIR}/game_data/materials DESTINATION share/games/aftn/game_data)
 endif(InstallMaterials)
 unset(InstallMaterials CACHE)
 
@@ -27,3 +39,5 @@ file(GLOB_RECURSE SRCS ${CMAKE_SOURCE_DIR}/src/*.c ${CMAKE_SOURCE_DIR}/src/map/*
 
 # Final
 add_executable(aftn ${SRCS})
+
+install(TARGETS aftn DESTINATION bin)

--- a/src/main.c
+++ b/src/main.c
@@ -13,8 +13,8 @@
 #include "manager.h"
 #include "map/map.h"
 
-const char *DEFAULT_MAP = "/var/games/aftn/game_data/maps/default";
-const char *BANNER = "/var/games/aftn/game_data/banner.txt";
+const char *DEFAULT_MAP = "/usr/share/games/aftn/game_data/maps/default";
+const char *BANNER = "/usr/share/games/aftn/game_data/banner.txt";
 
 const char *argp_program_version = "aftn 0.0.1";
 const char *argp_program_bug_address = "charles@utdallas.edu";
@@ -29,7 +29,7 @@ static struct argp_option options[] = {{"n_players", 'n', "integer", 0, "Number 
                                         "FILE",
                                         0,
                                         "Read game board from this path rather than the default. Check "
-                                        "/var/games/aftn/maps/format.txt to create your own game boards"},
+                                        "/usr/share/games/aftn/maps/format.txt to create your own game boards"},
                                        {"print_map", 'p', 0, 0, "Print out a text representation of the game map"},
                                        {"draw_map", 'd', 0, 0, "Draw the game map if an ASCII map is provided"},
                                        {0}};


### PR DESCRIPTION
Let the user override the used C standard with `-DCMAKE_C_STANDARD=11`
and the default build type with `-DCMAKE_BUILD_TYPE=Debug`.

To not require sudo for the cmake configuration step use the provided
install target. The install target is used by many package creation
helper.

Now the configure and build step can be done as user, and only the last
install step needs root to install to `/usr` by default.

```sh
cmake -S . -B build
cmake --build build
sudo cmake --build build --target install
```

The user can override the install directory by providing
`-DCMAKE_INSTALL_PREFIX=/usr`.

To better fit the install target (and because the map files are static architecture independent files) set the default installation path for the default map to `/usr/share/games/aftn/game_data/maps/default`